### PR TITLE
Check empty string in curl_exec

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -230,7 +230,7 @@ class Client {
 
         $res = curl_exec($ch);
 
-        if ($res === false) {
+        if ($res === false || $res === '') {
             throw new \Exception(curl_error($ch));
         }
 


### PR DESCRIPTION
If curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);, then $res will return empty string. The exception should be thrown if it fails to handshake, thus also checking for empty string.

http://www.php.net/manual/en/function.curl-exec.php#70123
