### PR TITLE
socket.io namespaces support

### DIFF
--- a/lib/ElephantIO/Frame.php
+++ b/lib/ElephantIO/Frame.php
@@ -8,10 +8,6 @@ namespace ElephantIO;
  *
  * $client->createFrame()->endPoint('/event')->emit('update', array(1,2,3));
  * $client->close();
- *
- * @method mixed getId
- * @method string getEndPoint
- *
  */
 class Frame {
 


### PR DESCRIPTION
added method of($endpoint) into Client.php
with this method you cant enter into some namespace

methods send and emit automatically register socket into getted endpoint
