### PR TITLE
Handle disconnection when sending message

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -140,7 +140,10 @@ class Client {
             ->setPayload($raw_message);
         $encoded = $payload->encodePayload();
 
-        fwrite($this->fd, $encoded);
+        $written = fwrite($this->fd, $encoded);
+	    if ($written === false || $written === 0) {
+		    throw new \Exception('Unable to send message to socket.io');
+	    }
 
         // wait 100ms before closing connexion
         usleep(100*1000);


### PR DESCRIPTION
An exception is now thrown if bytes can't be written to the socket, so the client can catch and try to reconnect.
