### PR TITLE
Support for namespaces

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -35,7 +35,7 @@ class Client {
     private $handshakeTimeout = null;
     private $namespace = "";
 
-    public function __construct($socketIOUrl, $socketIOPath = 'socket.io', $protocol = 1, $namespace = "", $read = true, $checkSslPeer = true, $debug = false) {
+    public function __construct($socketIOUrl, $socketIOPath = 'socket.io', $protocol = 1, $read = true, $checkSslPeer = true, $debug = false, $namespace = "") {
         $this->socketIOUrl = $socketIOUrl.'/'.$socketIOPath.'/'.(string)$protocol;
         $this->read = $read;
         $this->debug = $debug;


### PR DESCRIPTION
This update lets you set a namespace for your connection. You can then do something like this on your Socket.io server:

var socketio = require('socket.io');
var http = require('http');

var namespace = "/mynamespace";

var server = http.createServer().listen(config.port, function() {
    console.log("Server started, listening at " + config.port + " on namespace " + namespace);
});

var io = socketio.listen(server);

var api = io
    .of(namespace)
    .on('connection', function(socket) {
....
