### PR TITLE
Fixed PHPDoc in ElephantIO:init() function

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -46,7 +46,7 @@ class Client {
      * Initialize a new connection
      *
      * @param boolean $keepalive
-     * @return ElephantIOClient
+     * @return Client
      */
     public function init($keepalive = false) {
         $this->handshake();


### PR DESCRIPTION
The return type was not the good one, thus leading to IDE broken autocompletion
