### PR TITLE
Use ms constants only if we have curl >= 7.16.2

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -2,9 +2,6 @@
 
 namespace ElephantIO;
 
-require_once(__DIR__.'/Payload.php');
-
-
 /**
  * ElephantIOClient is a rough implementation of socket.io protocol.
  * It should ease you dealing with a socket.io server.
@@ -309,9 +306,21 @@ class Client {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
         }
 
-        if (!is_null($this->handshakeTimeout)) {
-            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $this->handshakeTimeout);
-            curl_setopt($ch, CURLOPT_TIMEOUT_MS, $this->handshakeTimeout);
+        if (null !== $this->handshakeTimeout) {
+            $timeout   = $this->handshakeTimeout;
+            $constants = array(CURLOPT_CONNECTTIMEOUT_MS, CURLOPT_TIMEOUT_MS);
+
+            $version = curl_version();
+            $version = $version['version'];
+
+            // CURLOPT_CONNECTTIMEOUT_MS and CURLOPT_TIMEOUT_MS were only implemented on curl 7.16.2
+            if (version_compare($version, '7.16.2') > -1) {
+                $timeout  *= 1000;
+                $constants = array(CURLOPT_CONNECTTIMEOUT, CURLOPT_TIMEOUT);
+            }
+
+            curl_setopt($ch, $constants[0], $timeout);
+            curl_setopt($ch, $constants[1], $timeout);
         }
 
         $res = curl_exec($ch);


### PR DESCRIPTION
This should avoid any warnings, as the constants `CURLOPT_CONNECTTIMEOUT_MS` and `CURLOPT_TIMEOUT_MS` are only available on curl >= 7.16.2

If we are below that version (should we still support it ? it is getting kinda old...), use the constants in seconds rather than milliseconds (`CURL_CONNECTTIMEOUT` and `CURL_TIMEOUT`), with a multiplication per 1000 for the `handshakeTimeout` parameter.

And I also took the liberty to remove the `require` in top of the `Client` class. We're using composer, so autoloading is not really our problem.

poke @guillaumepotier 
