### PR TITLE
Fix curl's version verification

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -314,7 +314,7 @@ class Client {
             $version = $version['version'];
 
             // CURLOPT_CONNECTTIMEOUT_MS and CURLOPT_TIMEOUT_MS were only implemented on curl 7.16.2
-            if (version_compare($version, '7.16.2') === 1) {
+            if (true === version_compare($version, '7.16.2', '<')) {
                 $timeout  /= 1000;
                 $constants = array(CURLOPT_CONNECTTIMEOUT, CURLOPT_TIMEOUT);
             }


### PR DESCRIPTION
Oops, something went awfully wrong ; we need to change to constant only if we have a version **below** (and not **below _or equal_**), and while we're at it, divide the timeout by 1000 rather than multiplying it by 1000. We want seconds, not nanoseconds !
