### PR TITLE
Fix Client read() function...

### DIFF
--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -99,8 +99,10 @@ abstract class AbstractSocketIO implements EngineInterface
 
         // the second byte contains the mask bit and the payload's length
         $data  .= $part = fread($this->stream, 1);
-        $length = (int)  (bin2hex($part) & ~0x80); // removing the mask bit
-        $mask   = (bool) (bin2hex($part) &  0x80);
+        $mask   = hexdec((bin2hex($part) &  0x80)) == 1;
+        $length = hexdec(bin2hex($part)); // Working...
+        //$length = bindec($part);        // Not working ?!
+        //$length = hexdec((bin2hex($part) & ~0x80)); // removing the mask bit
 
         /*
          * Here is where it is getting tricky :


### PR DESCRIPTION
 ... to allow to read small message sent by the server

Okay, to be clear, I'm not proud of this pull request. This is clearly NOT the best way to do it, but it works... 

The (int) and (bool) cast wasn't working for me and I don't know why. The more disapointing was the bindec function... I was supposing that hexdec(bin2hex()) = bindec() but it wasn't...

This code is ugly, but it works. Maybe this could inspire Taluu to do his magic stuff on it.