### PR TITLE
Adds the possibility to set the stream context of the connection

### DIFF
--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -41,6 +41,9 @@ abstract class AbstractSocketIO implements EngineInterface
     /** @var resource Resource to the connected stream */
     protected $stream;
 
+    /** @var mixed[] Array of php stream context wrappers */
+    protected $context;
+
     public function __construct($url, array $options = [])
     {
         $this->url     = $this->parseUrl($url);
@@ -189,6 +192,19 @@ abstract class AbstractSocketIO implements EngineInterface
         $server['secured'] = 'https' === $server['scheme'];
 
         return $server;
+    }
+
+    /** Initializes the stream context according to the options **/
+    protected function initContext() {
+        $this->context = [];
+        if (isset($this->options['context'])) {
+            if (isset($this->options['context']['http'])) {
+                $this->context['http'] = $this->options['context']['http'];
+            }
+            if (isset($this->options['context']['ssl'])) {
+                $this->context['ssl'] = $this->options['context']['ssl'];
+            }
+        }
     }
 
     /**

--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -208,6 +208,27 @@ abstract class AbstractSocketIO implements EngineInterface
     }
 
     /**
+     * Searches the origin in the headers. If not found return '*';
+     *
+     * @return string the origin
+     */
+    protected function getOrigin() {
+        $origin = '*';
+        $headers = '';
+        if (isset($this->context['http']['header'])) {
+            $headers = is_array($this->context['http']['header']) ? 
+                join(';', $this->context['http']['header']) : 
+                $this->context['http']['header'];
+        }
+
+        if (preg_match('/Origin:\s*(.*?)(;|$)/', $headers, $matches)) {
+            $origin = $matches[1];
+        }
+
+        return $origin;
+    }
+
+    /**
      * Get the defaults options
      *
      * @return array mixed[] Defaults options for this engine

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -84,6 +84,7 @@ class Version0X extends AbstractSocketIO
             return;
         }
 
+        $this->write(static::CLOSE);
         fclose($this->stream);
         $this->stream = null;
     }
@@ -91,7 +92,7 @@ class Version0X extends AbstractSocketIO
     /** {@inheritDoc} */
     public function emit($event, array $args)
     {
-        $this->write(static::EVENT, json_encode(['name' => $event, 'args' => $args]));
+        $this->write(static::MESSAGE, json_encode($args));
     }
 
     /** {@inheritDoc} */

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -56,6 +56,7 @@ class Version0X extends AbstractSocketIO
             return;
         }
 
+        $this->initializeContext();
         $this->handshake();
 
         $errors = [null, null];
@@ -65,7 +66,7 @@ class Version0X extends AbstractSocketIO
             $host = 'ssl://' . $host;
         }
 
-        $this->stream = stream_socket_client($host, $errors[0], $errors[1], $this->options['timeout'], STREAM_CLIENT_CONNECT, stream_context_create($this->options['context']));
+        $this->stream = stream_socket_client($host, $errors[0], $errors[1], $this->options['timeout'], STREAM_CLIENT_CONNECT, stream_context_create($this->context));
 
         if (!is_resource($this->stream)) {
             throw new SocketException($error[0], $error[1]);
@@ -143,7 +144,10 @@ class Version0X extends AbstractSocketIO
             $url .= '/?' . http_build_query($this->url['query']);
         }
 
-        $result = @file_get_contents($url, false, stream_context_create(['http' => ['timeout' => (float) $this->options['timeout']]]));
+        $context = $this->context;
+        $context['timeout'] = (float) $this->options['timeout'];
+
+        $result = @file_get_contents($url, false, stream_context_create($context));
 
         if (false === $result) {
             throw new ServerConnectionFailureException;

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -145,7 +145,7 @@ class Version0X extends AbstractSocketIO
         }
 
         $context = $this->context;
-        $context['timeout'] = (float) $this->options['timeout'];
+        $context['http']['timeout'] = (float) $this->options['timeout'];
 
         $result = @file_get_contents($url, false, stream_context_create($context));
 

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -56,7 +56,7 @@ class Version0X extends AbstractSocketIO
             return;
         }
 
-        $this->initializeContext();
+        $this->initContext();
         $this->handshake();
 
         $errors = [null, null];
@@ -186,7 +186,7 @@ class Version0X extends AbstractSocketIO
                  . "Connection: Upgrade\r\n"
                  . "Sec-WebSocket-Key: {$key}\r\n"
                  . "Sec-WebSocket-Version: 13\r\n"
-                 . "Origin: *\r\n\r\n";
+                 . "Origin: {$this->getOrigin()}\r\n\r\n";
 
         fwrite($this->stream, $request);
         $result = fread($this->stream, 12);

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -174,7 +174,7 @@ class Version1X extends AbstractSocketIO
                  . "Connection: Upgrade\r\n"
                  . "Sec-WebSocket-Key: {$key}\r\n"
                  . "Sec-WebSocket-Version: 13\r\n"
-                 . "Origin: *\r\n\r\n";
+                 . "Origin: {$this->getOrigin()}\r\n\r\n";
 
         fwrite($this->stream, $request);
         $result = fread($this->stream, 12);

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -139,8 +139,8 @@ class Version1X extends AbstractSocketIO
         }
         
         $context = $this->context;
-        $context['timeout'] = (float) $this->options['timeout'];
-
+        $context['http']['timeout'] = (float) $this->options['timeout'];
+        
         $url    = sprintf('%s://%s:%d/%s/?%s', $this->url['scheme'], $this->url['host'], $this->url['port'], trim($this->url['path'], '/'), http_build_query($query));
         $result = @file_get_contents($url, false, stream_context_create($context));
 

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -45,6 +45,7 @@ class Version1X extends AbstractSocketIO
             return;
         }
 
+        $this->initContext();
         $this->handshake();
 
         $errors = [null, null];
@@ -54,7 +55,7 @@ class Version1X extends AbstractSocketIO
             $host = 'ssl://' . $host;
         }
 
-        $this->stream = stream_socket_client($host, $errors[0], $errors[1], $this->options['timeout'], STREAM_CLIENT_CONNECT, stream_context_create($this->options['context']));
+        $this->stream = stream_socket_client($host, $errors[0], $errors[1], $this->options['timeout'], STREAM_CLIENT_CONNECT, stream_context_create($this->context));
 
         if (!is_resource($this->stream)) {
             throw new SocketException($errors[0], $errors[1]);
@@ -137,8 +138,8 @@ class Version1X extends AbstractSocketIO
             $query = array_replace($query, $this->url['query']);
         }
         
-        $context = $this->options['context'];
-        $context['http'] = ['timeout' => (float) $this->options['timeout']];
+        $context = $this->context;
+        $context['timeout'] = (float) $this->options['timeout'];
 
         $url    = sprintf('%s://%s:%d/%s/?%s', $this->url['scheme'], $this->url['host'], $this->url['port'], trim($this->url['path'], '/'), http_build_query($query));
         $result = @file_get_contents($url, false, stream_context_create($context));


### PR DESCRIPTION
Here is a example of how to set the context with custom headers :

```php
<?php

require_once 'vendor/autoload.php';

use ElephantIO\Client;
use ElephantIO\Engine\SocketIO\Version1X;

$url = 'http://localhost:12345';

$httpContext = [
	'header' => [
		'Origin: http://my-domain.com'
	]
];
$client = new Client(
	new Version1X($url, [ 
		'context' => [
			'http' => $httpContext
		]
	])
);
$client->initialize();
$client->emit('message', [ 'message' => 'Hello world']);
$client->close();
```