### PR TITLE
Allowing to set several namespaces during one session

### DIFF
--- a/example/socket.io/0.x/emitter-with-namespace/.gitignore
+++ b/example/socket.io/0.x/emitter-with-namespace/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/example/socket.io/0.x/emitter-with-namespace/client.php
+++ b/example/socket.io/0.x/emitter-with-namespace/client.php
@@ -12,7 +12,7 @@
 use ElephantIO\Client,
     ElephantIO\Engine\SocketIO\Version0X;
 
-require __DIR__ . '/../../../../../../../vendor/autoload.php';
+require __DIR__ . '/../../../../vendor/autoload.php';
 
 $client = new Client(new Version0X('http://localhost:1337'));
 

--- a/example/socket.io/0.x/emitter-with-namespace/client.php
+++ b/example/socket.io/0.x/emitter-with-namespace/client.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the Elephant.io package
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @copyright Wisembly
+ * @license   http://www.opensource.org/licenses/MIT-License MIT License
+ */
+
+use ElephantIO\Client,
+    ElephantIO\Engine\SocketIO\Version0X;
+
+require __DIR__ . '/../../../../../../../vendor/autoload.php';
+
+$client = new Client(new Version0X('http://localhost:1337'));
+
+$client->initialize();
+$client->of('/namespace');
+$client->emit('broadcast', ['foo' => 'bar']);
+$client->close();
+

--- a/example/socket.io/0.x/emitter-with-namespace/package.json
+++ b/example/socket.io/0.x/emitter-with-namespace/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "elephantIO_example_emitter_with_namespace",
+    "version": "3.0.0",
+    "main": "server.js",
+
+    "scripts": {
+        "start": "supervisor --debug server.js"
+    },
+
+    "dependencies": {
+        "socket.io": "~0.9",
+        "winston": "*"
+    }
+}

--- a/example/socket.io/0.x/emitter-with-namespace/server.js
+++ b/example/socket.io/0.x/emitter-with-namespace/server.js
@@ -1,0 +1,41 @@
+var logger = require('winston'),
+    port   = 1337;
+
+var io = require('socket.io').listen(port);
+
+// Logger config
+logger.remove(logger.transports.Console);
+logger.add(logger.transports.Console, { colorize: true, timestamp: true });
+logger.info('SocketIO > listening on port ' + port);
+
+io.of('/namespace').on('connection', function (socket){
+    var nb = 0;
+
+    logger.info('SocketIO /namespace > Connected socket ' + socket.id);
+
+    socket.on('broadcast', function (message) {
+        ++nb;
+        logger.info('ElephantIO /namespace broadcast > ' + JSON.stringify(message));
+    });
+
+    socket.on('disconnect', function () {
+        logger.info('SocketIO /namespace : Received ' + nb + ' messages');
+        logger.info('SocketIO /namespace > Disconnected socket ' + socket.id);
+    });
+});
+
+io.of('/namespace2').on('connection', function (socket){
+    var nb = 0;
+
+    logger.info('SocketIO /namespace2 > Connected socket ' + socket.id);
+
+    socket.on('broadcast', function (message) {
+        ++nb;
+        logger.info('ElephantIO /namespace2 broadcast > ' + JSON.stringify(message));
+    });
+
+    socket.on('disconnect', function () {
+        logger.info('SocketIO /namespace2 : Received ' + nb + ' messages');
+        logger.info('SocketIO /namespace2 > Disconnected socket ' + socket.id);
+    });
+});

--- a/example/socket.io/1.x/emitter-with-namespace/.gitignore
+++ b/example/socket.io/1.x/emitter-with-namespace/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/example/socket.io/1.x/emitter-with-namespace/client.php
+++ b/example/socket.io/1.x/emitter-with-namespace/client.php
@@ -12,7 +12,8 @@
 use ElephantIO\Client,
     ElephantIO\Engine\SocketIO\Version1X;
 
-require __DIR__ . '/../../../../../../../vendor/autoload.php';
+echo __DIR__."\n";
+require __DIR__ . '/../../../../vendor/autoload.php';
 
 $client = new Client(new Version1X('http://localhost:1337'));
 

--- a/example/socket.io/1.x/emitter-with-namespace/client.php
+++ b/example/socket.io/1.x/emitter-with-namespace/client.php
@@ -12,7 +12,6 @@
 use ElephantIO\Client,
     ElephantIO\Engine\SocketIO\Version1X;
 
-echo __DIR__."\n";
 require __DIR__ . '/../../../../vendor/autoload.php';
 
 $client = new Client(new Version1X('http://localhost:1337'));

--- a/example/socket.io/1.x/emitter-with-namespace/client.php
+++ b/example/socket.io/1.x/emitter-with-namespace/client.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the Elephant.io package
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @copyright Wisembly
+ * @license   http://www.opensource.org/licenses/MIT-License MIT License
+ */
+
+use ElephantIO\Client,
+    ElephantIO\Engine\SocketIO\Version1X;
+
+require __DIR__ . '/../../../../../../../vendor/autoload.php';
+
+$client = new Client(new Version1X('http://localhost:1337'));
+
+$client->initialize();
+$client->of('/namespace');
+$client->emit('broadcast', ['foo' => 'bar']);
+$client->close();

--- a/example/socket.io/1.x/emitter-with-namespace/package.json
+++ b/example/socket.io/1.x/emitter-with-namespace/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "elephantIO_example_emitter_with_namespace",
+    "version": "3.0.0",
+    "main": "server.js",
+
+    "scripts": {
+        "start": "supervisor --debug server.js"
+    },
+
+    "dependencies": {
+        "socket.io": "~1.0.6",
+        "winston": "*"
+    }
+}

--- a/example/socket.io/1.x/emitter-with-namespace/server.js
+++ b/example/socket.io/1.x/emitter-with-namespace/server.js
@@ -1,0 +1,44 @@
+var server     = require('http').createServer(),
+    io         = require('socket.io')(server),
+    logger     = require('winston'),
+    port       = 1337;
+
+// Logger config
+logger.remove(logger.transports.Console);
+logger.add(logger.transports.Console, { colorize: true, timestamp: true });
+logger.info('SocketIO > listening on port ' + port);
+
+io.of('/namespace').on('connection', function (socket){
+    var nb = 0;
+
+    logger.info('SocketIO /namespace > Connected socket ' + socket.id);
+
+    socket.on('broadcast', function (message) {
+        ++nb;
+        logger.info('ElephantIO /namespace broadcast > ' + JSON.stringify(message));
+    });
+
+    socket.on('disconnect', function () {
+        logger.info('SocketIO /namespace : Received ' + nb + ' messages');
+        logger.info('SocketIO /namespace > Disconnected socket ' + socket.id);
+    });
+});
+
+io.of('/namespace2').on('connection', function (socket){
+    var nb = 0;
+
+    logger.info('SocketIO /namespace2 > Connected socket ' + socket.id);
+
+    socket.on('broadcast', function (message) {
+        ++nb;
+        logger.info('ElephantIO /namespace2 broadcast > ' + JSON.stringify(message));
+    });
+
+    socket.on('disconnect', function () {
+        logger.info('SocketIO /namespace2 : Received ' + nb + ' messages');
+        logger.info('SocketIO /namespace2 > Disconnected socket ' + socket.id);
+    });
+});
+
+server.listen(port);
+

--- a/src/Client.php
+++ b/src/Client.php
@@ -99,6 +99,20 @@ class Client
     }
 
     /**
+     * Sets the namespace for the next messages
+     *
+     * @param string namespace the name of the namespace
+     * @return $this
+     */
+    public function of($namespace)
+    {
+        null !== $this->logger && $this->logger->debug('Setting the namespace', ['namespace' => $namespace]);
+        $this->engine->of($namespace);
+
+        return $this;
+    }
+
+    /**
      * Closes the connection
      *
      * @return $this

--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -41,8 +41,12 @@ abstract class AbstractSocketIO implements EngineInterface
     /** @var resource Resource to the connected stream */
     protected $stream;
 
+    /** @var string the namespace of the next message */
+    protected $namespace;
+
     public function __construct($url, array $options = [])
     {
+        $this->namespace = '';
         $this->url     = $this->parseUrl($url);
         $this->options = array_replace($this->getDefaultOptions(), $options);
     }
@@ -63,6 +67,11 @@ abstract class AbstractSocketIO implements EngineInterface
     public function close()
     {
         throw new UnsupportedActionException($this, 'close');
+    }
+
+    /** {@inheritDoc} */
+    public function of($namespace) {
+        $this->namespace = $namespace;
     }
 
     /**
@@ -198,10 +207,10 @@ abstract class AbstractSocketIO implements EngineInterface
      */
     protected function getDefaultOptions()
     {
-        return ['context' => [],
-                'debug'   => false,
-                'wait'    => 100*1000,
-                'timeout' => ini_get("default_socket_timeout")];
+        return ['context'   => [],
+                'debug'     => false,
+                'wait'      => 100*1000,
+                'timeout'   => ini_get("default_socket_timeout")];
     }
 }
 

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -104,13 +104,19 @@ class Version0X extends AbstractSocketIO
             throw new InvalidArgumentException('Wrong message type when trying to write on the socket');
         }
 
-        $payload = new Encoder($code . ':::' . $message, Encoder::OPCODE_TEXT, true);
+        $payload = new Encoder($code . '::'.$this->namespace.':' . $message, Encoder::OPCODE_TEXT, true);
         $bytes = fwrite($this->stream, (string) $payload);
 
         // wait a little bit of time after this message was sent
         usleep($this->options['wait']);
 
         return $bytes;
+    }
+
+    /** {@inheritDoc} */
+    public function of($namespace) {
+        parent::of($namespace);
+        $this->write(static::OPEN);
     }
 
     /** {@inheritDoc} */

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -81,7 +81,14 @@ class Version1X extends AbstractSocketIO
     /** {@inheritDoc} */
     public function emit($event, array $args)
     {
-        return $this->write(EngineInterface::MESSAGE, static::EVENT . json_encode([$event, $args]));
+         $namespace = ($this->namespace != '') ? $this->namespace.',' : '';
+        return $this->write(EngineInterface::MESSAGE, static::EVENT . $namespace . json_encode([$event, $args]));
+    }
+
+    /** {@inheritDoc} */
+    public function of($namespace) {
+        parent::of($namespace);
+        $this->write(EngineInterface::MESSAGE, static::CONNECT . $this->namespace);
     }
 
     /** {@inheritDoc} */

--- a/src/EngineInterface.php
+++ b/src/EngineInterface.php
@@ -57,5 +57,8 @@ interface EngineInterface
 
     /** Gets the name of the engine */
     public function getName();
+
+    /** Sets the namespace for the next messages */
+    public function of($namespace);
 }
 

--- a/src/EngineInterface.php
+++ b/src/EngineInterface.php
@@ -58,7 +58,11 @@ interface EngineInterface
     /** Gets the name of the engine */
     public function getName();
 
-    /** Sets the namespace for the next messages */
+    /** 
+     * Sets the namespace for the next messages
+     *
+     * @param string $namespace the namespace
+     */
     public function of($namespace);
 }
 


### PR DESCRIPTION
This PR gives the possibility to connect to one or more namespaces during a connection.

```php
$client = new Client(
	new Version1X($url)
);
$client->initialize();
// Send message to /namespace1
$client->of('/namespace1');
$client->emit('message', [ 'message' => 'Hello world']);

// Send message to /namespace2
$client->of('/namespace2');
$client->emit('message', [ 'message' => 'Hello world']);

// Reset to no namespace
$client->of('');
$client->emit('message', [ 'message' => 'Hello world']);
$client->close();
```