### PR TITLE
Fix for read function not reading the correct number of bytes

### DIFF
--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -99,8 +99,8 @@ abstract class AbstractSocketIO implements EngineInterface
 
         // the second byte contains the mask bit and the payload's length
         $data  .= $part = fread($this->stream, 1);
-        $length = (int)  (bin2hex($part) & ~0x80); // removing the mask bit
-        $mask   = (bool) (bin2hex($part) &  0x80);
+        $length = hexdec(bin2hex($part) & ~0x80); // removing the mask bit
+        $mask   = (bool)(bin2hex($part) &  0x80);
 
         /*
          * Here is where it is getting tricky :


### PR DESCRIPTION
Hi again. After upgrading to new Elephant.IO version from legacy one, I realised that when reading from Socket.IO, the messages were incorrect. After a bit of study I found that the calculation of the number of bytes to read were wrong because it was treated as an integer number when it was an hex and the mold wasn't converting the value correctly from hex to integer.

Here comes a quick pull request with the change to make the read function usable.

Hope that it helps!