### PR TITLE
Format host correctly

### DIFF
--- a/lib/ElephantIO/Client.php
+++ b/lib/ElephantIO/Client.php
@@ -356,9 +356,12 @@ class Client {
         }
 
         $key = $this->generateKey();
+        
+        $url = parse_url($this->serverHost);
+        $host = sprintf('%s:%d', $url['host'], array_key_exists('port', $url) ? $url['port'] : 80);
 
         $out  = "GET ".$this->serverPath."/websocket/".$this->session['sid']." HTTP/1.1\r\n";
-        $out .= "Host: ".$this->serverHost."\r\n";
+        $out .= "Host: ".$host."\r\n";
         $out .= "Upgrade: WebSocket\r\n";
         $out .= "Connection: Upgrade\r\n";
         $out .= "Sec-WebSocket-Key: ".$key."\r\n";


### PR DESCRIPTION
I had a problem where the `ssl://` part in the `Host:` header caused a 400 Bad Request from Socket.IO (though it could also have been nginx's fault since I reverse proxy the socket.io server through it), which I fixed by properly formatting the `Host:` header (according to the HTTP RFC, there should not be mention of a scheme in this header).