### PR TITLE
Fix path when connection url have query string

### DIFF
--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -198,11 +198,15 @@ abstract class AbstractSocketIO implements EngineInterface
 
         $server = array_replace(['scheme' => 'http',
                                  'host'   => 'localhost',
-                                 'query'  => [],
-                                 'path'   => 'socket.io'], $parsed);
+                                 'query'  => []
+                                ], $parsed);
 
         if (!isset($server['port'])) {
             $server['port'] = 'https' === $server['scheme'] ? 443 : 80;
+        }
+        
+        if (!isset($server['path']) || $server['path']=='/') {
+            $server['path'] = 'socket.io';
         }
 
         if (!is_array($server['query'])) {


### PR DESCRIPTION
Example: http://socket.io.server.dev:3000?token=jwt