### PR TITLE
Cookie-based sticky sessions support for handshake and upgrade transport

### DIFF
--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -34,6 +34,9 @@ abstract class AbstractSocketIO implements EngineInterface
     /** @var string[] Parse url result */
     protected $url;
 
+    /** @var array cookies received during handshake */
+    protected $cookies = [];
+
     /** @var string[] Session information */
     protected $session;
 


### PR DESCRIPTION
Hello,

We are using Amazon load-balancer that does a cookie-based sticky sessions.
Without this patch handshake and upgrade transport requests are routed to different underlying node.js instances and connection fails.