### PR TITLE
Add Socket.IO v2 support

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -78,7 +78,7 @@ class Client
     /**
      * Reads a message from the socket
      *
-     * @return MessageInterface Message read from the socket
+     * @return string Message read from the socket
      */
     public function read()
     {
@@ -88,6 +88,9 @@ class Client
 
     /**
      * Emits a message through the engine
+     *
+     * @param string $event
+     * @param array  $args
      *
      * @return $this
      */

--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -12,6 +12,7 @@
 namespace ElephantIO\Engine;
 
 use DomainException;
+use ElephantIO\Engine\SocketIO\Session;
 use RuntimeException;
 
 use Psr\Log\LoggerInterface;
@@ -37,7 +38,7 @@ abstract class AbstractSocketIO implements EngineInterface
     /** @var array cookies received during handshake */
     protected $cookies = [];
 
-    /** @var string[] Session information */
+    /** @var Session Session information */
     protected $session;
 
     /** @var mixed[] Array of options for the engine */
@@ -189,6 +190,8 @@ abstract class AbstractSocketIO implements EngineInterface
 
     /**
      * Parse an url into parts we may expect
+     *
+     * @param string $url
      *
      * @return string[] information on the given URL
      */

--- a/src/Engine/SocketIO/Session.php
+++ b/src/Engine/SocketIO/Session.php
@@ -42,7 +42,12 @@ class Session
                             'interval' => $interval];
     }
 
-    /** The property should not be modified, hence the private accessibility on them */
+	/**
+	 * The property should not be modified, hence the private accessibility on them
+	 *
+	 * @param string $prop
+	 * @return mixed
+	 */
     public function __get($prop)
     {
         static $list = ['id', 'upgrades'];

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -187,15 +187,17 @@ class Version1X extends AbstractSocketIO
     }
 
     /** Upgrades the transport to WebSocket */
-    private function upgradeTransport()
+    protected function upgradeTransport()
     {
         $query = ['sid'       => $this->session->id,
                   'EIO'       => $this->options['version'],
-                  'use_b64'   => $this->options['use_b64'],
                   'transport' => static::TRANSPORT_WEBSOCKET];
 
+	    if ($this->options['version'] === 2)
+	        $query['use_b64'] = $this->options['use_b64'];
+
         $url = sprintf('/%s/?%s', trim($this->url['path'], '/'), http_build_query($query));
-        $key = base64_encode(random_bytes(20));
+        $key = base64_encode(openssl_random_pseudo_bytes(16));
 
         $origin = '*';
         $headers = isset($this->context['headers']) ? (array) $this->context['headers'] : [] ;

--- a/src/Payload/Encoder.php
+++ b/src/Payload/Encoder.php
@@ -25,11 +25,12 @@ use ElephantIO\AbstractPayload;
 class Encoder extends AbstractPayload
 {
     private $data;
+    /** @var string */
     private $payload;
 
     /**
      * @param string  $data   data to encode
-     * @param integer $opcode OpCode to use (one of AbstractPayload's constant)
+     * @param integer $opCode OpCode to use (one of AbstractPayload's constant)
      * @param bool    $mask   Should we use a mask ?
      */
     public function __construct($data, $opCode, $mask)


### PR DESCRIPTION
My site depends on this library for communicating with a separately running Node.js socket.io server, and I noticed that as of version 2.0.0 of socket.io Elephant.IO is failing to connect to the socket.io server and sending messages.

Therefore I dug into the code and messed around with it until the Node.js server was logging that it got the messages again. I can't guarantee with 100% certainty that this change set will permanently fix the issues as I don't have deep understanding of WebSockets or socket.io's API, but for the time being I managed to send messages with it and I consider that to be better than an error message saying 
> in_array expects parameter 2 to be array, null given in .../src/Engine/SocketIO/Version1X.php on line [172](https://github.com/Wisembly/elephant.io/blob/master/src/Engine/SocketIO/Version1X.php#L172)

I'd highly appreciate if this fix could be merged for the sake of anyone else trying to upgrade.