### PR TITLE
Fix Client->read() function

### DIFF
--- a/example/socket.io/1.x/receiver/client.php
+++ b/example/socket.io/1.x/receiver/client.php
@@ -14,17 +14,66 @@ use ElephantIO\Engine\SocketIO\Version1X;
 
 require __DIR__ . '/../../../../vendor/autoload.php';
 
-$client = new Client(new Version1X('http://localhost:1337'));
+$handshakeQuery = '/?foo=bar&bar=foo'; //this will be available on io.on('connection', function(socket){ socket.handshake.query.foo / .bar });
+$socketOptions  = array('context' =>
+	                        array('http' => array(
+		                        'header' => "Accept-language: en,\r\n" .
+			                        "Origin: https://www.example.com,\r\n" .
+			                        "Cookie: foo=bar; \r\n"
+	                        )));
+
+$client = new Client(new Version1X('http://localhost:1337' . $handshakeQuery, $socketOptions));
 
 $client->initialize();
+$data = waitForEvent($client, 'message', 5);
 
-while (true) {
-    $r = $client->read();
-
-    if (!empty($r)) {
-        var_dump($r);
-    }
-}
+//example: server->emit('message', 'hello world');
+//$data = hello world or false on timeout
 
 $client->close();
 
+/**
+ * @param     $socket  , ElephantIO\Client
+ * @param     $event   , string
+ * @param int $timeout , float comparator
+ *
+ * @return mixed
+ * @since
+ */
+function waitForEvent($socket, $event, $timeout = 5)
+{
+	$time_start = microtime(true);
+	try
+	{
+		while (true)
+		{
+			$res = $socket->read();
+			if (!empty($res))
+			{
+				if (strpos($res, '42') === 0) //starts with 42
+				{
+					$res = str_replace(substr($res, 0, 2), '', $res);
+				}
+				$data = json_decode($res);//successful event will start with 42["event","data"]
+				if (is_array($data) && $data[0] == $event)
+				{
+					return $data[1];
+				}
+				elseif (is_array($data))
+				{
+					return waitForEvent($socket, $event, $timeout); // we have data, but not as expected
+				}
+			}
+			if ((microtime(true) - $time_start) > $timeout) //server is not responding in time, brake
+			{
+				break;
+			}
+		}
+	}
+	catch (\ElephantIO\Exception\ServerConnectionFailureException $e)
+	{
+		var_dump($e->getMessage());
+	}
+
+	return false;//no data found
+}

--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -117,7 +117,14 @@ abstract class AbstractSocketIO implements EngineInterface
          * opcode... We're not interested in them. Yet.
          * the second byte contains the mask bit and the payload's length
          */
+	    stream_set_blocking($this->stream, false);
         $data = fread($this->stream, 2);
+
+        if ($data == '')
+        {
+        	return '';
+        }
+
         $bytes = unpack('C*', $data);
 
         $mask = ($bytes[2] & 0b10000000) >> 7;


### PR DESCRIPTION
The kind of change this PR does introduce

- [x]  a bug fix
- [ ]  a new feature
- [x]  an update to the documentation
- [x]  a code change that improves performance
- [ ]  other

Current behavior
Client->read() is hanging the script until data is received.
New behavior
Client->read() will return empty string if no data is received.
Other information (e.g. related issues)
This answers #73, #149, #137 and perhaps #60