### PR TITLE
added custom headers option to handshake

### DIFF
--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -159,6 +159,12 @@ class Version1X extends AbstractSocketIO
         }
 
         $context[$this->url['secured'] ? 'ssl' : 'http']['timeout'] = (float) $this->options['timeout'];
+        
+        // add customer headers
+        if(array_key_exists("headers", $this->options)){
+            $headers = $context[$this->url['secured'] ? 'ssl' : 'http']['header'] ?: [];
+            $context[$this->url['secured'] ? 'ssl' : 'http']['header'] = array_merge($headers, $this->options['headers']);
+        }
 
         $url    = sprintf('%s://%s:%d/%s/?%s', $this->url['scheme'], $this->url['host'], $this->url['port'], trim($this->url['path'], '/'), http_build_query($query));
         $result = @file_get_contents($url, false, stream_context_create($context));

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -162,8 +162,8 @@ class Version1X extends AbstractSocketIO
         
         // add customer headers
         if(array_key_exists("headers", $this->options)){
-            $headers = $context[$this->url['secured'] ? 'ssl' : 'http']['header'] ?: [];
-            $context[$this->url['secured'] ? 'ssl' : 'http']['header'] = array_merge($headers, $this->options['headers']);
+            $headers = $context['http']['header'] ?: [];
+            $context['http']['header'] = array_merge($headers, $this->options['headers']);
         }
 
         $url    = sprintf('%s://%s:%d/%s/?%s', $this->url['scheme'], $this->url['host'], $this->url['port'], trim($this->url['path'], '/'), http_build_query($query));


### PR DESCRIPTION
Manually specified headers (e.g. Authorization, Referer ...) can be useful for some security check or custom logic inside socket.io `use` method.