### PR TITLE
Moar context to ServerConnectionFailureException

### DIFF
--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -179,7 +179,14 @@ class Version0X extends AbstractSocketIO
         $result = @file_get_contents($url, false, stream_context_create($context));
 
         if (false === $result) {
-            throw new ServerConnectionFailureException;
+            $message = null;
+            $error = error_get_last();
+
+            if (null !== $error && false !== strpos($error['message'], 'file_get_contents()')) {
+                $message = $error['message'];
+            }
+
+            throw new ServerConnectionFailureException($message);
         }
 
         $sess = explode(':', $result);

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -177,7 +177,14 @@ class Version1X extends AbstractSocketIO
         $result = @file_get_contents($url, false, stream_context_create($context));
 
         if (false === $result) {
-            throw new ServerConnectionFailureException;
+            $message = null;
+            $error = error_get_last();
+
+            if (null !== $error && false !== strpos($error['message'], 'file_get_contents()')) {
+                $message = $error['message'];
+            }
+
+            throw new ServerConnectionFailureException($message);
         }
 
         $open_curly_at = strpos($result, '{');

--- a/src/Engine/SocketIO/Version2X.php
+++ b/src/Engine/SocketIO/Version2X.php
@@ -11,20 +11,6 @@
 
 namespace ElephantIO\Engine\SocketIO;
 
-use DomainException;
-use InvalidArgumentException;
-use UnexpectedValueException;
-
-use Psr\Log\LoggerInterface;
-
-use ElephantIO\EngineInterface;
-use ElephantIO\Payload\Encoder;
-use ElephantIO\Engine\AbstractSocketIO;
-
-use ElephantIO\Exception\SocketException;
-use ElephantIO\Exception\UnsupportedTransportException;
-use ElephantIO\Exception\ServerConnectionFailureException;
-
 /**
  * Implements the dialog with Socket.IO version 2.x
  *

--- a/src/Exception/ServerConnectionFailureException.php
+++ b/src/Exception/ServerConnectionFailureException.php
@@ -16,9 +16,19 @@ use RuntimeException;
 
 class ServerConnectionFailureException extends RuntimeException
 {
-    public function __construct(Exception $previous = null)
+    /** @var string php error message */
+    private $errorMessage;
+
+    public function __construct($errorMessage, Exception $previous = null)
     {
         parent::__construct('An error occurred while trying to establish a connection to the server', 0, $previous);
+
+        $this->errorMessage = $errorMessage;
+    }
+
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
     }
 }
 


### PR DESCRIPTION
Add a way to get more information on the dreaded `ServerConnectionFailureException`. This should fix #150, fix #153, fix #157, fix #160 and fix #161. Or at least add more information, as these are more support issues than real bugs (unless something is really wrong which I highly doubt so).