### PR TITLE
Implementing ping

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -50,10 +50,9 @@ class Client
     /**
      * Connects to the websocket
      *
-     * @param boolean $keepAlive keep alive the connection (not supported yet) ?
      * @return $this
      */
-    public function initialize($keepAlive = false)
+    public function initialize()
     {
         try {
             $this->logger->debug('Connecting to the websocket');
@@ -61,11 +60,6 @@ class Client
             $this->logger->debug('Connected to the server');
 
             $this->isConnected = true;
-
-            if (true === $keepAlive) {
-                $this->logger->debug('Keeping alive the connection to the websocket');
-                $this->engine->keepAlive();
-            }
         } catch (SocketException $e) {
             $this->logger->error('Could not connect to the server', ['exception' => $e]);
 

--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -74,7 +74,6 @@ abstract class AbstractSocketIO implements EngineInterface
     /** {@inheritDoc} */
     public function keepAlive()
     {
-        throw new UnsupportedActionException($this, 'keepAlive');
     }
 
     /** {@inheritDoc} */
@@ -115,6 +114,7 @@ abstract class AbstractSocketIO implements EngineInterface
             return;
         }
 
+        $this->keepAlive();
         /*
          * The first byte contains the FIN bit, the reserved bits, and the
          * opcode... We're not interested in them. Yet.

--- a/src/Engine/SocketIO/Session.php
+++ b/src/Engine/SocketIO/Session.php
@@ -26,7 +26,7 @@ class Session
     /** @var integer session's last heartbeat */
     private $heartbeat;
 
-    /** @var integer[] session's and heartbeat's timeouts */
+    /** @var float[] session's and heartbeat's timeouts */
     private $timeouts;
 
     /** @var string[] supported upgrades */
@@ -36,10 +36,10 @@ class Session
     {
         $this->id        = $id;
         $this->upgrades  = $upgrades;
-        $this->heartbeat = \time();
+        $this->heartbeat = \microtime(true);
 
-        $this->timeouts  = ['timeout'  => $timeout,
-                            'interval' => $interval];
+        $this->timeouts  = ['timeout'  => (float)$timeout,
+                            'interval' => (float)$interval];
     }
 
     /**
@@ -66,8 +66,8 @@ class Session
      */
     public function needsHeartbeat()
     {
-        if (0 < $this->timeouts['interval'] && \time() > ($this->timeouts['interval'] + $this->heartbeat - 5)) {
-            $this->heartbeat = \time();
+        if (0 < $this->timeouts['interval'] && \microtime(true) > ($this->timeouts['interval'] + $this->heartbeat - 5)) {
+            $this->heartbeat = \microtime(true);
 
             return true;
         }

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -225,8 +225,8 @@ class Version1X extends AbstractSocketIO
 
         $this->session = new Session(
             $decoded['sid'],
-            $decoded['pingInterval'],
-            $decoded['pingTimeout'],
+            $decoded['pingInterval'] / 1000,
+            $decoded['pingTimeout'] / 1000,
             $decoded['upgrades']
         );
     }

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -35,12 +35,6 @@ class Version1X extends AbstractSocketIO
     const TRANSPORT_POLLING   = 'polling';
     const TRANSPORT_WEBSOCKET = 'websocket';
 
-    /**
-     * Keep connection alive
-     * @var bool
-     */
-    protected $keepAlive = false;
-
     /** {@inheritDoc} */
     public function connect()
     {
@@ -101,7 +95,7 @@ class Version1X extends AbstractSocketIO
     /** {@inheritDoc} */
     public function emit($event, array $args)
     {
-        $this->ping();
+        $this->keepAlive();
         $namespace = $this->namespace;
 
         if ('' !== $namespace) {
@@ -114,7 +108,7 @@ class Version1X extends AbstractSocketIO
     /** {@inheritDoc} */
     public function of($namespace)
     {
-        $this->ping();
+        $this->keepAlive();
         parent::of($namespace);
 
         $this->write(EngineInterface::MESSAGE, static::CONNECT . $namespace);
@@ -314,26 +308,7 @@ class Version1X extends AbstractSocketIO
      */
     public function keepAlive()
     {
-        $this->keepAlive = true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function read()
-    {
-       $message = parent::read();
-       $this->ping();
-
-       return $message;
-    }
-
-    /**
-     * Send Ping packet
-     */
-    protected function ping()
-    {
-        if ($this->keepAlive && $this->session->needsHeartbeat()) {
+        if ($this->session->needsHeartbeat()) {
             $this->write(static::PING);
         }
     }


### PR DESCRIPTION
This pull request adds the ping functionality in order to keep the connection alive.

To keep the engine interface backward compatible, ping packets are sent implicitly during socket interaction method calls. This behaviour is controlled by `keepAlive()` method. Ping timestamp is stored for future usage to verify the connection state using pong packet's timestamp and timeout value.

It also adds the timeouts conversion, as server responds with timeouts in milliseconds.

I was unable to test it against 0.x protocol version, so it's implementation is left untouched. If anyone can verify these changes are suitable, they can be backported to `Version0X` engine.