### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 cache:
   - bin

--- a/composer.json
+++ b/composer.json
@@ -33,17 +33,23 @@
     ],
 
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.1.0",
         "psr/log": "~1.0"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^8.0 || ^7.0"
     },
 
     "autoload": {
         "psr-4": {
-            "ElephantIO\\": ["src/", "test/"]
+            "ElephantIO\\": "src/"
+        }
+    },
+
+    "autoload-dev": {
+        "psr-4": {
+            "ElephantIO\\": "test/"
         }
     },
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,11 +7,15 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     >
     <testsuites>
         <testsuite name="Elephant.io test suite">
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/test/AbstractPayloadTest.php
+++ b/test/AbstractPayloadTest.php
@@ -11,12 +11,13 @@
 
 namespace ElephantIO;
 
-use ReflectionMethod,
-    ReflectionProperty;
+use ReflectionMethod;
 
-use PHPUnit_Framework_TestCase;
+use ReflectionProperty;
 
-class AbstractPayloadTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractPayloadTest extends TestCase
 {
     public function testMaskData()
     {

--- a/test/Payload/DecoderTest.php
+++ b/test/Payload/DecoderTest.php
@@ -13,9 +13,9 @@ namespace ElephantIO\Payload;
 
 use ReflectionProperty;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DecoderTest extends PHPUnit_Framework_TestCase
+class DecoderTest extends TestCase
 {
     /** @dataProvider providerUnmaskedPayload */
     public function testUnmaskedPayload($payload, $expected)

--- a/test/Payload/EncoderTest.php
+++ b/test/Payload/EncoderTest.php
@@ -13,9 +13,9 @@ namespace ElephantIO\Payload;
 
 use ReflectionProperty;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class EncoderTest extends PHPUnit_Framework_TestCase
+class EncoderTest extends TestCase
 {
     /** @dataProvider providerShortPayload */
     public function testShortPayload($maskKey, $expected)


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test in Travis CI build.
- Using the namespace for `autoload` and `autoload-dev` to load classes in `src` and `test` folders.
- Add the white filter list in `phpunit.xml` setting to evaluate the code coverage reference.
- Using the PHPUnit `^4.8` version and class-based `PHPUnit` namespace to be compatible with latest stable PHPUnit version.