### PR TITLE
Update package.json dependencies

### DIFF
--- a/example/socket.io/2.x/emitter-with-headers/package.json
+++ b/example/socket.io/2.x/emitter-with-headers/package.json
@@ -1,12 +1,16 @@
 {
-    "name": "elephantIO_example_emitter_with_headers",
+    "name": "elephant-io_example_emitter_with_headers",
     "version": "1.0.0",
     "main": "server.js",
     "scripts": {
-        "start": "supervisor --debug server.js"
+        "start": "supervisor --inspect server.js"
+    },
+    "engines": {
+        "node": ">=10.15"
     },
     "dependencies": {
-        "socket.io": "~2",
-        "winston": "*"
+        "socket.io": "^2",
+        "supervisor": "^0.12.0",
+        "winston": "^2"
     }
 }


### PR DESCRIPTION
# Changed log
- Fix package name because original name is not valid.
- The supervisor `--debug` is deprecated and using the `--inspect` option instead.
- Define the Node.js version requirement at least.
- Set the current version definitions for every dependency and it can avoid unexpected dependency error.