### PR TITLE
Update Version1X.php

### DIFF
--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -180,8 +180,8 @@ class Version1X extends AbstractSocketIO
 
         // add customer headers
         if (isset($this->options['headers'])) {
-            $headers = isset($context[$protocol]['header']) ? $context[$protocol]['header'] : [];
-            $context[$protocol]['header'] = \array_merge($headers, $this->options['headers']);
+            $headers = isset($context['http']['header']) ? $context['http']['header'] : [];
+            $context['http']['header'] = array_merge($headers, $this->options['headers']);
         }
 
         $url    = \sprintf(


### PR DESCRIPTION
to set custom headers over an SSL connection, there is a small change to make in the Version1X.php file.

you have to force the protocol used for the headers on 'http' because, according to the documentation, the modification of header can not be done in the SSL context, only in HTTP context.